### PR TITLE
Fix swagger source URL

### DIFF
--- a/index.html
+++ b/index.html
@@ -10,7 +10,7 @@
   <script src="https://unpkg.com/swagger-ui-dist/swagger-ui-bundle.js"></script>
   <script>
     SwaggerUIBundle({
-      url: "wms_to_mfm_openapi_spec.yaml",
+      url: "wms_to_sfm_openapi_spec.yaml",
       dom_id: "#swagger-ui"
     });
   </script>


### PR DESCRIPTION
Since the filename changed, this needs to be updated to make the Github page work again.